### PR TITLE
Enable QR code scanner

### DIFF
--- a/ui/app/components/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/modals/qr-scanner/qr-scanner.component.js
@@ -114,12 +114,15 @@ export default class QrScanner extends Component {
     // For ex. EIP-681 (https://eips.ethereum.org/EIPS/eip-681)
 
     // Bitcoin Cash address links - fox ex. ethereum:0x.....1111
-    if (content.split('ethereum:').length > 1) {
+    if (content.split('bitcoincash:').length > 1) {
       type = 'address'
-      values = { address: content.split('ethereum:')[1] }
+      values = { address: content.split('bitcoincash:')[1] }
 
       // Regular ethereum addresses - fox ex. 0x.....1111
-    } else if (content.substring(0, 2).toLowerCase() === '0x') {
+    } else if (
+      content.substring(0, 1).toLowerCase() === 'q' ||
+      content.substring(0, 1).toLowerCase() === 'p'
+    ) {
       type = 'address'
       values = { address: content }
     }

--- a/ui/app/components/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/modals/qr-scanner/qr-scanner.component.js
@@ -118,7 +118,7 @@ export default class QrScanner extends Component {
       content.split('bitcoincash:').length > 1 ||
       content.split('simpleledger:').length > 1
     ) {
-      // Cash Address format
+      // Cash and SimpleLedger Address format
       type = 'address'
       values = { address: content }
     } else if (

--- a/ui/app/components/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/modals/qr-scanner/qr-scanner.component.js
@@ -114,14 +114,17 @@ export default class QrScanner extends Component {
     // For ex. EIP-681 (https://eips.ethereum.org/EIPS/eip-681)
 
     // Bitcoin Cash address links - fox ex. ethereum:0x.....1111
-    if (content.split('bitcoincash:').length > 1) {
+    if (
+      content.split('bitcoincash:').length > 1 ||
+      content.split('simpleledger:').length > 1
+    ) {
+      // Cash Address format
       type = 'address'
-      values = { address: content.split('bitcoincash:')[1] }
-
-      // Regular ethereum addresses - fox ex. 0x.....1111
+      values = { address: content }
     } else if (
-      content.substring(0, 1).toLowerCase() === 'q' ||
-      content.substring(0, 1).toLowerCase() === 'p'
+      (content.substring(0, 1).toLowerCase() === 'q' &&
+        content.length === 42) ||
+      (content.substring(0, 1).toLowerCase() === 'p' || content.length === 42)
     ) {
       type = 'address'
       values = { address: content }

--- a/ui/app/components/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/app/components/modals/qr-scanner/qr-scanner.component.js
@@ -115,8 +115,8 @@ export default class QrScanner extends Component {
 
     // Bitcoin Cash address links - fox ex. ethereum:0x.....1111
     if (
-      content.split('bitcoincash:').length > 1 ||
-      content.split('simpleledger:').length > 1
+      (content.split('bitcoincash:').length > 1 && content.length === 54) ||
+      (content.split('simpleledger:').length > 1 && content.length === 55)
     ) {
       // Cash and SimpleLedger Address format
       type = 'address'


### PR DESCRIPTION
Properly scan QR codes w/ `bitcoincash:` and `simpleledger:` prefixes as well as addresses that start w/ `q` or `p` which are 42 characters long.